### PR TITLE
Add preview in CP content index table 

### DIFF
--- a/src/fields/ManyToManyField.php
+++ b/src/fields/ManyToManyField.php
@@ -160,7 +160,7 @@ class ManyToManyField extends Field implements PreviewableFieldInterface
             'value' => $value,
             'id' => $namespacedId,
             'current' => $relatedEntries,
-            'section' => $relatedSection->id,
+            'section' => $relatedSection->uid,
             'nonSelectable' => $nonSelectable,
             'singleField' => $this->singleField,
             'nameSpace' => Craft::$app->view->getNamespace(),

--- a/src/fields/ManyToManyField.php
+++ b/src/fields/ManyToManyField.php
@@ -4,6 +4,7 @@ namespace Page8\ManyToMany\fields;
 
 use Craft;
 use Craft\base\Field;
+use craft\base\PreviewableFieldInterface;
 use craft\elements\Entry;
 use Page8\ManyToMany\Plugin;
 use craft\base\ElementInterface;
@@ -11,7 +12,7 @@ use craft\base\ElementInterface;
 /**
  * @property string $settingsHtml
  */
-class ManyToManyField extends Field
+class ManyToManyField extends Field implements PreviewableFieldInterface
 {
     /**
      * Section source
@@ -177,4 +178,26 @@ class ManyToManyField extends Field
 
         parent::afterElementSave($element, $isNew);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTableAttributeHtml($value, ElementInterface $element): string
+    {
+        $plugin = Plugin::getInstance();
+        $service = $plugin->service;
+
+        $relatedSection = Craft::$app->sections->getSectionById($this->source['value']);
+        $relatedEntries = $service->getRelatedEntries($element, $relatedSection, $this->singleField);
+
+        $element = $relatedEntries[0] ?? null;
+
+        if ($element) {
+            return Craft::$app->getView()->renderTemplate('_elements/element', [
+                'element' => $element
+            ]);
+        }
+        return '';
+        }
+
 }

--- a/src/fields/ManyToManyField.php
+++ b/src/fields/ManyToManyField.php
@@ -180,6 +180,8 @@ class ManyToManyField extends Field implements PreviewableFieldInterface
     }
 
     /**
+     * Picks the first entry of a revers relationship (if any) and displays as link in the CP content table list
+     *
      * @inheritdoc
      */
     public function getTableAttributeHtml($value, ElementInterface $element): string
@@ -198,6 +200,6 @@ class ManyToManyField extends Field implements PreviewableFieldInterface
             ]);
         }
         return '';
-        }
+    }
 
 }


### PR DESCRIPTION
Picks the first entry of a revers relationship (if any) and displays as link in the entries index table/list. Similar to the native Craft relations-field.