### PR TITLE
Fix craft namespace in ManyToMany field

### DIFF
--- a/src/fields/ManyToManyField.php
+++ b/src/fields/ManyToManyField.php
@@ -3,7 +3,7 @@
 namespace Page8\ManyToMany\fields;
 
 use Craft;
-use Craft\base\Field;
+use craft\base\Field;
 use craft\elements\Entry;
 use Page8\ManyToMany\Plugin;
 use craft\base\ElementInterface;


### PR DESCRIPTION
Should fix the casing in the craft field namespace as described here:
https://github.com/Pageworks/craft-manytomany/issues/20