### PR TITLE
Fix empty modal when choosing inverse relation entries

### DIFF
--- a/src/fields/ManyToManyField.php
+++ b/src/fields/ManyToManyField.php
@@ -159,7 +159,7 @@ class ManyToManyField extends Field
             'value' => $value,
             'id' => $namespacedId,
             'current' => $relatedEntries,
-            'section' => $relatedSection->id,
+            'section' => !empty($relatedSection->uid) ? $relatedSection->uid : $relatedSection->id,
             'nonSelectable' => $nonSelectable,
             'singleField' => $this->singleField,
             'nameSpace' => Craft::$app->view->getNamespace(),


### PR DESCRIPTION
Fix for [issue #24](https://github.com/Pageworks/craft-manytomany/issues/24):
When picking entries for the inverse relationship, the modal would turn up empty.

I've left id (old field name, is now uid) as a fallback to support older Craft versions.

Feedback & tips welcome.