### PR TITLE
Makes getTableAttributeHtml use default CP rendering

### DIFF
--- a/src/fields/ManyToManyField.php
+++ b/src/fields/ManyToManyField.php
@@ -159,16 +159,10 @@ class ManyToManyField extends Field implements PreviewableFieldInterface
         parent::afterElementSave($element, $isNew);
     }
 
-    public function getTableAttributeHtml($value, ElementInterface $element): string
-    {
-        if ($value) {
-            return Craft::$app->getView()->renderTemplate('_elements/element', [
-                'element' => $value[0],
-            ]);
-        }
-
-        return '';
-    }
+	public function getTableAttributeHtml($value, ElementInterface $element): string
+	{
+		return Cp::elementPreviewHtml($value);
+	}
 
     public function getContentGqlType(): array
     {


### PR DESCRIPTION
Currently the list view only shows the first element that is connected to the entry.

Using the core `Cp::elementPreviewHtml` method will however deal with multiple values and display a clickable [+1] label in case of more than 1.

Before:
![image](https://github.com/verbb/many-to-many/assets/13553242/07f38ccd-4e34-44e5-9c8d-d64136475a31)

After:
![image](https://github.com/verbb/many-to-many/assets/13553242/4f8f3aee-7bf4-442d-9912-589fb8110889)
