### PR TITLE
Typo `many-to-many` -> `manytomany`

### DIFF
--- a/docs/get-started/installation-setup.md
+++ b/docs/get-started/installation-setup.md
@@ -14,5 +14,5 @@ cd /path/to/project
 
 2. Then tell Composer to require the plugin, and Craft to install it:
 ```shell
-composer require verbb/many-to-many && php craft plugin/install many-to-many
+composer require verbb/many-to-many && php craft plugin/install manytomany
 ```


### PR DESCRIPTION
Quick fix for updating installation instructions, since `manytomany` is the correct identifier. See screenshot below:

![Schermafbeelding 2024-01-04 om 11 43 41](https://github.com/verbb/many-to-many/assets/1833361/1859920e-e4a5-4c55-a4b8-b506dab6be83)
