### PR TITLE
Fix error when saving relations that include a disabled entry

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -84,15 +84,25 @@ class Service extends Component
         $toDelete = !empty($content['delete']) ? $content['delete'] : [];
 
         foreach ($toAdd as $sourceId) {
-            $sourceElement = Entry::find()->id($sourceId)->one();
+            $sourceElement = Entry::find()->id($sourceId)->status(null)->one();
+
+            if (!$sourceElement) {
+                continue;
+            }
+
             $currentRelations = array_map(fn($r) => $r->Id, $sourceElement->getFieldValue($field->handle)->all());
             $currentRelations = array_unique(array_merge($currentRelations, [$targetId]));
             $sourceElement->setFieldValue($field->handle, $currentRelations);
             Craft::$app->elements->saveElement($sourceElement);
         }
-        
+
         foreach ($toDelete as $sourceId) {
-            $sourceElement = Entry::find()->id($sourceId)->one();
+            $sourceElement = Entry::find()->id($sourceId)->status(null)->one();
+
+            if (!$sourceElement) {
+                continue;
+            }
+
             $currentRelations = array_map(fn($r) => $r->Id, $sourceElement->getFieldValue($field->handle)->all());
             $currentRelations = array_filter($currentRelations, fn($r) => $r != $targetId);
             $sourceElement->setFieldValue($field->handle, $currentRelations);


### PR DESCRIPTION
Saving a Many-to-many field that has a disabled entry in it throws `Call to a member function getFieldValue() on null`, because the entry queries in `saveRelationship()` use the default `enabled` status and so don't find disabled source entries.

This sets `status(null)` on those queries (the same way `getRelatedEntries()` already does) so disabled entries are picked up, and skips any id that no longer resolves to an entry. Fixes #56.